### PR TITLE
Improved shell scripts

### DIFF
--- a/groundTruth/micro-benchmark/snippets/test.sh
+++ b/groundTruth/micro-benchmark/snippets/test.sh
@@ -6,31 +6,37 @@
 # Created Time: 六  9/18 10:50:24 2021
 #########################################################################
 # shellcheck disable=SC1068
-start_pycg(){
-  entry='/Users/yixuanyan/yyx/github/supplychain/YanYiXuan/pythonCG/main.py'
-	for element in `ls $1`
-	do	
+
+start_pycg () {
+  entry="/Users/yixuanyan/yyx/github/supplychain/YanYiXuan/pythonCG/main.py"
+	for element in `ls "$1"`
+	do
 		file=$1"/"$element
-		if [ -d $file ]
-		then	
-			start_pycg $file	
+		if [ -d "$file" ]
+		then
+			start_pycg "$file"
 		elif [ "${file##*.}"x = "py"x ]
-		then	
-			# echo $file
+		then
 			if [ ${file##*/}x = 'main.py'x ]
 			then
-			  	curDir="${file%/*}/test.json"
-				curDir_pythonCG="${file%/*}/oldCG.json"
-				curDir_pycg="${file%/*}/pycg.json"
-				# pycg "$file" --package ${file%/*} -o "$curDir_pycg"
-#				python3 ${entry} "$file" --package ${file%/*} -o "$curDir_pythonCG"
-				/usr/bin/time -lp pycg "$file" --package ${file%/*} > ${file%/*}/pycg.log 2>&1
-				/usr/bin/time -lp python3 ${entry} "$file" --package ${file%/*} > ${file%/*}/pythoncg.log 2>&1
+				# Normal PyCG usage (uncomment the following line 2 lines)
+				# curDir_pycg="${file%/*}/pycg.json"
+				# pycg "$file" --package "${file%/*}" -o "$curDir_pycg"
+
+				# Normal pythoncg/Jarvis usage (uncomment the following line 2 lines)
+				# curDir_pythonCG="${file%/*}/oldCG.json"
+				# python3 "$entry" "$file" --package "${file%/*}" -o "$curDir_pythonCG"
+
+				# Timing PyCG and pythoncg/Jarvis in a log file
+				/usr/bin/time -lp pycg "$file" --package "${file%/*}" > "${file%/*}/pycg.log" 2>&1
+				/usr/bin/time -lp python3 "$entry" "$file" --package "${file%/*}" > "${file%/*}/pythoncg.log" 2>&1
 			fi
 		fi
-	done	
+	done
 }
+
 path="/Users/yixuanyan/yyx/github/supplychain/YanYiXuan/pythonCG/micro-benchmark/snippets"
-start_pycg $path
+start_pycg "$path"
+
 #path="/Users/yixuanyan/yyx/github/supplychain/YanYiXuan/pythonCG/micro-benchmark/snippets/generators/"
-#start_pycg $path
+#start_pycg "$path"

--- a/groundTruth/micro-benchmark/snippets/test_edge.sh
+++ b/groundTruth/micro-benchmark/snippets/test_edge.sh
@@ -1,33 +1,32 @@
+#!/bin/bash
 #########################################################################
 # File Name:    test_edge.sh
-#!/bin/bash
-start_pycg(){
-  entry='/Users/yixuanyan/yyx/github/supplychain/callGraph/pythonCG/micro-benchmark/snippets/getEdege.py'
-	for element in `ls $1`
+#########################################################################
+
+start_pycg () {
+  entry="/Users/yixuanyan/yyx/github/supplychain/YanYiXuan/pythonCG/main.py"
+	for element in `ls "$1"`
 	do
 		file=$1"/"$element
-		if [ -d $file ]
+		if [ -d "$file" ]
 		then
-			start_pycg $file
+			start_pycg "$file"
 		elif [ "${file##*.}"x = "py"x ]
 		then
-			echo $file
 			if [ ${file##*/}x = 'main.py'x ]
 			then
-			  curDir="${file%/*}/test.json"
+			  curDir_pycg="${file%/*}/test_pycg.json"
 				curDir_pythonCG="${file%/*}/test_pythonCG.json"
-				curDir_pycg="${file%/*}/test_pycg.json"
 				curDir_output="${file%/*}/output.txt"
         echo
         if  [ ! -f "$curDir_output"  ]; then
-				  rm -rf curDir_output
+				  rm -rf "$curDir_output"
 				fi
-        python3 ${entry} $curDir_pythonCG $curDir_pycg $curDir_output
-
+        python3 "$entry" "$curDir_pythonCG" "$curDir_pycg" "$curDir_output"
 			fi
 		fi
 	done
 }
+
 path="/Users/yixuanyan/yyx/github/supplychain/callGraph/pythonCG/micro-benchmark/snippets"
 start_pycg $path
-


### PR DESCRIPTION
- The shell scripts now also work for directories that contain spaces and apostrophe characters.

**Why this PR?**
- I tried to run the test.sh file with the following directory: `D:\Documents\TU Delft\Year 6\Master's Thesis\pythonJaRvis.github.io\Jarvis\main.py`. However, this didn't work as the arguments in the shell script didn't allow spaces in the name. Therefore it crashed...
